### PR TITLE
Fixed ReDoS

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "babel-runtime": "^6.26.0",
     "lodash": "^4.17.4",
     "md5": "^2.2.1",
+    "safe-regex": "^2.1.1",
     "url-regex": "^4.1.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
     "babel-runtime": "^6.26.0",
     "lodash": "^4.17.4",
     "md5": "^2.2.1",
-    "url-regex": "^4.1.1",
     "validator": "^13.1.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -49,8 +49,8 @@
     "babel-runtime": "^6.26.0",
     "lodash": "^4.17.4",
     "md5": "^2.2.1",
-    "safe-regex": "^2.1.1",
-    "url-regex": "^4.1.1"
+    "url-regex": "^4.1.1",
+    "validator": "^13.1.1"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",

--- a/src/utils/isResource.js
+++ b/src/utils/isResource.js
@@ -1,6 +1,5 @@
 // External Packages
-const safe = require('safe-regex')
-import UrlRegex from 'url-regex'
+import validator from 'validator';
 
 /**
  * @constant {Object} urlRegex The URL regex to test.
@@ -14,9 +13,5 @@ const urlRegex = UrlRegex({ exact: true })
  * @returns {boolean} Whether or not a resource is valid.
  */
 export default function isResource(resource) {
-  if (!safe(resource)) {
-    console.log(`Error: Invalid Regex`)
-    process.exit(1)
-  }
-  return urlRegex.test(resource)
+  return validator.isURL(resource)
 }

--- a/src/utils/isResource.js
+++ b/src/utils/isResource.js
@@ -1,5 +1,5 @@
 // External Packages
-import validator from 'validator';
+import validator from 'validator'
 
 /**
  * @constant {Object} urlRegex The URL regex to test.

--- a/src/utils/isResource.js
+++ b/src/utils/isResource.js
@@ -1,4 +1,5 @@
 // External Packages
+const safe = require('safe-regex')
 import UrlRegex from 'url-regex'
 
 /**
@@ -13,5 +14,9 @@ const urlRegex = UrlRegex({ exact: true })
  * @returns {boolean} Whether or not a resource is valid.
  */
 export default function isResource(resource) {
+  if (!safe(resource)) {
+    console.log(`Error: Invalid Regex`)
+    process.exit(1)
+  }
   return urlRegex.test(resource)
 }


### PR DESCRIPTION
### 📊 Metadata *

#### Bounty URL:  https://www.huntr.dev/bounties/1-npm-restql

### ⚙️ Description *

`restql` is vulnerable to **ReDoS** (Regex Denial of Service) when we give an extended improper URL.

### 💻 Technical Description *

The project uses the module `url-regex` which is vulnerable to ReDoS, using the `validator` module instead of this one is enough to fix the issue.

### 🐛 Proof of Concept (PoC) *

```javascript
var restql = require("restql");

/**
 * @constant {string} resource The resource to fetch.
 */
const resource = 'https://pokeapi.co.asdasdasd.asdsadasdsadsad.asdasdsad.asdsadasdsa.sadasdsadas.dasdasasdasd.432asdas3423.3423423423.234234243.234234234.23423423.24234.'

/**
 * @constant {Object} resolver The resolver to apply.
 */
const resolver = {
  'abilities[]?.ability.url': {
    'generation.url': {
      'main_region.url': null,
    },
  },
  'stats[].stat.url?': {
    'affecting_natures.increase[].url': null,
    'affecting_natures.decrease[].url': null,
  },
  'moves[].move?.url': null,
}

/**
 * @constant {Object} options The options to bypass.
 */
const options = {
  // ...
};

(async () => {
  try {
    const data = await restql(resource, resolver, options)

    console.log(data)
  } catch (error) {
    console.error(error.message)
  }
})()
```

**After running the PoC:**

_The program halts (DoSed)_

![Screenshot from 2020-07-29 20-40-33](https://user-images.githubusercontent.com/26198477/88819113-2bbcea00-d1dd-11ea-8713-28bc8305e89c.png)

### 🔥 Proof of Fix (PoF) *

_Throws the inbuilt error for invalid resource URLs_

![Screenshot from 2020-07-29 20-41-18](https://user-images.githubusercontent.com/26198477/88819064-1cd63780-d1dd-11ea-8649-452f539cf00e.png)

### 👍 User Acceptance Testing (UAT)

Just used the module `validator` instead of `url-regex` which is vulnerable to ReDoS.